### PR TITLE
fix(guide): correct noun examples and nominalization

### DIFF
--- a/docs/guide/nouns.md
+++ b/docs/guide/nouns.md
@@ -212,10 +212,10 @@ Examples:
 
 - *Akin ang libro.*  
   (The book is mine.)
-- *Bahay niya ito.*  
-  (This is his/her house.)
-- *Sasakyan namin yan.*  
-  (That is our vehicle.)
+- *Kanya ang bahay na ito.*  
+  (This house is his/hers.)
+- *Amin ang sasakyan na yan.*  
+  (That vehicle is ours.)
 
 ### Using Attributive Possessive Pronouns
 
@@ -264,7 +264,7 @@ Verbs and adjectives can be nominalized (turned into nouns) through affixation.
 Creates abstract nouns from verb roots:
 
 - *kain* (eat) → *pagkain* (food)
-- *luto* (cook) → *pagluto* (cooking)
+- *luto* (cook) → *pagluluto* (cooking)
 - *ibig* (want) → *pag-ibig* (love)
 
 ### Using *Ka-* -*an* Circumfix


### PR DESCRIPTION
This PR fixes mismatched examples in the Possessive Pronouns section and corrects a nominalization example in the Nouns guide.